### PR TITLE
fix: otp sent for report recipe

### DIFF
--- a/src/components/ReportIt.vue
+++ b/src/components/ReportIt.vue
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <div class="ui red fluid button" :title="title" @click="ReportIt">
+        <div class="ui red fluid button" :title="title" @click="reportIt">
             <i class="ui bug icon"></i>
             Report it
         </div>
@@ -109,19 +109,30 @@
                         </div>
                     </div>
                     <br />
-                    <div>
+                    <div >
                         <label for="emailorphone"
                             >Please provide your email or phone number:
                             (Required*)</label
                         >
-                        <div class="field">
-                            <input
-                                type="text"
-                                v-model="formData.email"
-                                ref="emailorphone"
-                                name="emailorphone"
-                                required
-                            />
+                        <div class="ui grid">
+                            <div class="field ui email ten wide computer column sixteen wide mobile column">
+                                <input
+                                    type="text"
+                                    v-model="formData.email"
+                                    ref="emailorphone"
+                                    name="emailorphone"
+                                    required
+                                />
+                            </div>
+                            <div class="ui input six wide computer column sixteen wide mobile column">
+                                <button
+                                    class="ui tbb button otp"
+                                    @click="requestOtp"
+                                    v-bind:class="{ loading: is_loading }"
+                                >
+                                    Send Code
+                                </button>
+                            </div>
                         </div>
                     </div>
                     <br />
@@ -133,6 +144,7 @@
                                 ref="verificationcode"
                                 v-model="formData.verification_code"
                                 name="verificationcode"
+                                required
                             />
                         </div>
                     </div>
@@ -148,10 +160,20 @@
                         <i class="close icon"></i>
                         <div>Your report was submitted.</div>
                     </div>
-                  
+
                     <div class="ui negative message" v-if="report_failed">
                         <i class="close icon"></i>
                         <div>Error sending report.</div>
+                    </div>
+
+                    <div class="ui success message" v-if="otp_success">
+                        <i class="close icon"></i>
+                        <div>OTP has been sent the number or email above.</div>
+                    </div>
+
+                    <div class="ui negative message otp" v-if="otp_failed">
+                        <i class="close icon"></i>
+                        <div>Error sending OTP.</div>
                     </div>
                     <div class="">
                         <div class="ui input">
@@ -187,10 +209,15 @@ export default {
         report_failed() {
             return this.$store.state.subscriptionStore.failed;
         },
+        otp_success() {
+            return this.$store.state.subscriptionStore.otp_success;
+        },
+        otp_failed() {
+            return this.$store.state.subscriptionStore.otp_failed;
+        },
     },
 
     data() {
-        
         return {
             showModal: false,
             title: "Use this tool if you think this recipe is any of the following; inappropriate, unauthentic, not original, stolen or a duplicate.",
@@ -210,10 +237,14 @@ export default {
     },
 
     methods: {
-        ReportIt() {
+        reportIt() {
             this.resetForm();
             this.$store.dispatch("reset_report_form");
             $(".ui.modal").modal("show");
+        },
+
+        requestOtp() {
+            store.dispatch("submit_report_otp", this.formData.email);
         },
         resetForm() {
             // Reset the form data after successful submission
@@ -289,9 +320,9 @@ export default {
     display: block;
 }
 
-.ui.modal input[name="verificationcode"] {
+.ui.modal input[name="verificationcode"], .ui.modal input[name="emailorphone"] {
     width: 100%;
-    padding: 5px;
+    padding: 10px;
     border: 1px solid #ccc;
 }
 
@@ -316,5 +347,9 @@ export default {
 
 .message {
     margin-bottom: 20px !important;
+}
+
+.email{
+    margin-top: 12px
 }
 </style>

--- a/src/store/modules/subscriptionStore.js
+++ b/src/store/modules/subscriptionStore.js
@@ -2,6 +2,8 @@ export const subscriptionStore = {
     state: () => ({
         success: false,
         report_success: false,
+        otp_success: false,
+        otp_failed: false,
         failed: false,
     }),
     mutations: {
@@ -20,12 +22,20 @@ export const subscriptionStore = {
         RESET_REPORT_FORM(state) {
             state.report_success = false;
             state.failed = false;
+            state.otp_success = false;
+            state.otp_failed = false;
         },
         SHOW_REPORT_SUCCESS_MESSAGE(state) {
             state.report_success = true;
         },
+        SHOW_OTP_SUCCESS_MESSAGE(state) {
+            state.otp_success = true;
+        },
         SHOW_FAILED_MESSAGE(state) {
             state.failed = true;
+        },
+        SHOW_FAILED_OTP(state) {
+            state.otp_failed = true;
         },
     },
     actions: {
@@ -64,20 +74,55 @@ export const subscriptionStore = {
 
             const url = process.env.BASE_URL + "report-recipe";
 
-            this.state.api.client.post(url, {
-                payload
-            }, this.state.api.options, {  headers: {
-                'Authorization': `Bearer ${this.state.access_token}`
-            }})
-            .then((response) => {
-                context.commit('SET_MODAL_STATE', false)
-                context.commit('SHOW_REPORT_SUCCESS_MESSAGE')
-            })
-            .catch((error) => {
-                context.commit('SET_MODAL_STATE', false)
-                context.commit('SHOW_FAILED_MESSAGE')
-                context.commit("HANDLE_ERROR", error.response);
-            })
+            this.state.api.client
+                .post(
+                    url,
+                    {
+                        payload,
+                    },
+                    this.state.api.options,
+                    {
+                        headers: {
+                            Authorization: `Bearer ${this.state.access_token}`,
+                        },
+                    },
+                )
+                .then((response) => {
+                    context.commit("SET_MODAL_STATE", false);
+                    context.commit("SHOW_REPORT_SUCCESS_MESSAGE");
+                })
+                .catch((error) => {
+                    context.commit("SET_MODAL_STATE", false);
+                    context.commit("SHOW_FAILED_MESSAGE");
+                    context.commit("HANDLE_ERROR", error.response);
+                });
+        },
+        submit_report_otp(context, payload) {
+            context.commit("SET_MODAL_STATE", true);
+
+            const url = process.env.BASE_URL + "otp"; //not actual endpoint
+
+            this.state.api.client
+                .post(
+                    url,
+                    {
+                        payload,
+                    },
+                    {
+                        headers: {
+                            Authorization: `Bearer ${this.state.access_token}`,
+                        },
+                    },
+                )
+                .then((response) => {
+                    context.commit("SET_MODAL_STATE", false);
+                    context.commit("SHOW_OTP_SUCCESS_MESSAGE");
+                })
+                .catch((error) => {
+                    context.commit("SET_MODAL_STATE", false);
+                    context.commit("SHOW_FAILED_OTP");
+                    context.commit("HANDLE_ERROR", error.response);
+                });
         },
         reset_report_form(context) {
             context.commit("RESET_REPORT_FORM");

--- a/test/e2e/specs/ReportIt.spec.js
+++ b/test/e2e/specs/ReportIt.spec.js
@@ -2,11 +2,16 @@ module.exports = {
     "ReportIt Component Test": function (browser) {
         browser
             .url(`${process.env.VUE_APP_APP_URL}#/recipes/egusi-soup`)
-            .waitForElementVisible(".six.wide.computer.column.sixteen.wide.mobile.column", 15000)
+            .waitForElementVisible(
+                ".six.wide.computer.column.sixteen.wide.mobile.column",
+                15000,
+            )
             .waitForElementVisible(".ui.red.fluid.button", 9000000)
             .click(".ui.red.fluid.button")
             .waitForElementVisible(".ui.modal", 5000)
             .setValue('input[name="emailorphone"]', "test@example.com")
+            .click("button.ui.tbb.button.otp")
+            .waitForElementVisible(".ui.success.message", 9000000)
             .click('input[name="nudity"]')
             .click('input[name="irrelevant"]')
             .click('input[name="violation"]')


### PR DESCRIPTION
# Issue - #169

# Description

- This PR fixes the issue of sending otp to the user before allowing them to submit a report on a recipe

# How Has This Been Tested?
I updated the reportit test file to ensure a request is made to the backend to get an otp , then tested that the form cant be sent without an otp entered

# Checklist:
- [ ✅] I have rebased my branch against the base branch
- [✅ ] My code follows the style guidelines of this project (4 spaces instead of 2)
- [ ✅] I have performed a self-review of my code. 
- [ ✅] I have cleaned my commits